### PR TITLE
feat: add ALLOWED_ORIGINS environment variable for backend deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -126,6 +126,7 @@ jobs:
             INTERNAL_PORT=8080
             DB_HOST=host.docker.internal
             DB_PORT=27017
+            ALLOWED_ORIGINS=http://agilewheel.miguelsmuller.dev.br,https://agilewheel.miguelsmuller.dev.br
           service: 'agile-wheel-backend'
           image: 'docker.io/miguelsmuller/agile-wheel-backend:latest'
 


### PR DESCRIPTION
This pull request makes a small but important update to the `.github/workflows/deploy-backend.yml` file to enhance deployment configuration. The change introduces a new environment variable to specify allowed origins for the backend service.

Deployment configuration update:

* [`.github/workflows/deploy-backend.yml`](diffhunk://#diff-2418b8c74e15fc5d4f708e1f98749f0d592abf1991ce915d251f77ed076e5f7dR129): Added the `ALLOWED_ORIGINS` environment variable to define permitted origins (`http://agilewheel.miguelsmuller.dev.br,https://agilewheel.miguelsmuller.dev.br`) for the backend service.