### PR TITLE
test(frontend): add unit tests for guards, use cases, and ActivityComponent

### DIFF
--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -4,8 +4,8 @@ sonar.organization=miguelsmuller
 sonar.sources=src
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
-# sonar.coverage.exclusions=**/*.spec.ts
-sonar.coverage.exclusions=**
+sonar.coverage.exclusions=**/*.spec.ts
+# sonar.coverage.exclusions=**
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=agile-wheel

--- a/frontend/src/application/guards/validate-activity.guard.spec.ts
+++ b/frontend/src/application/guards/validate-activity.guard.spec.ts
@@ -1,0 +1,100 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { of } from 'rxjs';
+
+import { AgileWheelBackEndHTTP } from 'adapters/http/agile-wheel-backend.http';
+import {
+  activityFixture,
+  regularParticipantFixture,
+  createRoute,
+  mockLocalStorage,
+} from 'testing/fixtures';
+
+import { ValidateActitivityGuard } from './validate-activity.guard';
+
+describe('ValidateActitivityGuard', () => {
+  let guard: ValidateActitivityGuard;
+
+  let routerSpy: jasmine.SpyObj<Router>;
+  let httpSpy: jasmine.SpyObj<AgileWheelBackEndHTTP>;
+
+  beforeEach(() => {
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    httpSpy = jasmine.createSpyObj<AgileWheelBackEndHTTP>('AgileWheelBackEndHTTP', ['get']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ValidateActitivityGuard,
+        { provide: Router, useValue: routerSpy },
+        { provide: AgileWheelBackEndHTTP, useValue: httpSpy },
+      ],
+    });
+
+    guard = TestBed.inject(ValidateActitivityGuard);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('should redirect when id is missing', async () => {
+    // GIVEN
+    mockLocalStorage(activityFixture, regularParticipantFixture);
+
+    // WHEN
+    // eslint-disable-next-line sonarjs/no-undefined-argument
+    const result = await guard.canActivate(createRoute(undefined)); // id is undefined
+
+    // THEN
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/create-activity']);
+  });
+
+  it('should redirect when localStorage data is missing', async () => {
+    // GIVEN
+    mockLocalStorage(null, null);
+
+    // WHEN
+    const result = await guard.canActivate(createRoute('a1'));
+
+    // THEN
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/create-activity']);
+  });
+
+  it('should redirect when activity id mismatches', async () => {
+    // GIVEN
+    mockLocalStorage(activityFixture, regularParticipantFixture);
+
+    // WHEN
+    const result = await guard.canActivate(createRoute('wrong'));
+
+    // THEN
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/create-activity']);
+  });
+
+  it('should redirect when backend returns invalid activity', async () => {
+    // GIVEN
+    mockLocalStorage(activityFixture, regularParticipantFixture);
+    httpSpy.get.and.returnValue(of({ activity: { ...activityFixture, activity_id: 'x' } }));
+
+    // WHEN
+    const result = await guard.canActivate(createRoute('a1'));
+
+    // THEN
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/create-activity']);
+  });
+
+  it('should allow navigation when everything matches', async () => {
+    // GIVEN
+    mockLocalStorage(activityFixture, regularParticipantFixture);
+    httpSpy.get.and.returnValue(of({ activity: activityFixture }));
+
+    // WHEN
+    const result = await guard.canActivate(createRoute('a1'));
+
+    // THEN
+    expect(result).toBeTrue();
+  });
+});

--- a/frontend/src/application/use-cases/activity-flow.facade.spec.ts
+++ b/frontend/src/application/use-cases/activity-flow.facade.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import {
+  activityFixture,
+  regularParticipantFixture,
+  ownerParticipantFixture,
+} from 'testing/fixtures';
+
+import { ActivityFlowFacade } from './activity-flow.facade';
+import { CloseActivityUserCase } from './close-activity.usecase';
+import { SubmitEvaluationUseCase } from './submit-evaluation.usecase';
+
+describe('ActivityFlowFacade', () => {
+  let facade: ActivityFlowFacade;
+
+  let submitSpy: jasmine.SpyObj<SubmitEvaluationUseCase>;
+  let closeSpy: jasmine.SpyObj<CloseActivityUserCase>;
+
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    submitSpy = jasmine.createSpyObj<SubmitEvaluationUseCase>('SubmitEvaluationUseCase', [
+      'execute',
+    ]);
+    closeSpy = jasmine.createSpyObj<CloseActivityUserCase>('CloseActivityUserCase', ['execute']);
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    localStorage.setItem('activity', JSON.stringify(activityFixture));
+    localStorage.setItem('participant', JSON.stringify(ownerParticipantFixture));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ActivityFlowFacade,
+        { provide: SubmitEvaluationUseCase, useValue: submitSpy },
+        { provide: CloseActivityUserCase, useValue: closeSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    facade = TestBed.inject(ActivityFlowFacade); 
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('should submit only when participant is not owner', async () => {
+    // WHEN
+    await facade.execute(activityFixture, regularParticipantFixture, []);
+
+    // THEN
+    expect(submitSpy.execute).toHaveBeenCalledWith(activityFixture, regularParticipantFixture, []);
+    expect(closeSpy.execute).not.toHaveBeenCalled();
+    expect(localStorage.getItem('activity')).toEqual(JSON.stringify(activityFixture));
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should close activity and navigate when participant is owner', async () => {
+    // WHEN
+    await facade.execute(activityFixture, ownerParticipantFixture, []);
+
+    // THEN
+    expect(closeSpy.execute).toHaveBeenCalledWith(activityFixture, ownerParticipantFixture);
+    expect(localStorage.getItem('activity')).toBeNull();
+    expect(localStorage.getItem('participant')).toBeNull();
+    expect(routerSpy.navigate).toHaveBeenCalledWith([
+      `activity/${activityFixture.activity_id}/result`,
+    ]);
+  });
+});

--- a/frontend/src/application/use-cases/close-activity.usecase.spec.ts
+++ b/frontend/src/application/use-cases/close-activity.usecase.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
+
+import { AgileWheelBackEndHTTP } from 'adapters/http/agile-wheel-backend.http';
+import { activityFixture, regularParticipantFixture } from 'testing/fixtures';
+
+import { CloseActivityUserCase } from './close-activity.usecase';
+
+describe('CloseActivityUserCase', () => {
+  let usecase: CloseActivityUserCase;
+
+  let httpSpy: jasmine.SpyObj<AgileWheelBackEndHTTP>;
+
+  beforeEach(() => {
+    httpSpy = jasmine.createSpyObj<AgileWheelBackEndHTTP>('AgileWheelBackEndHTTP', ['post']);
+    httpSpy.post.and.returnValue(of({}));
+
+    TestBed.configureTestingModule({
+      providers: [CloseActivityUserCase, { provide: AgileWheelBackEndHTTP, useValue: httpSpy }],
+    });
+
+    usecase = TestBed.inject(CloseActivityUserCase);
+  });
+
+  it('should call backend with correct endpoint and headers', () => {
+    // WHEN
+    usecase.execute(activityFixture, regularParticipantFixture);
+
+    // THEN
+    expect(httpSpy.post).toHaveBeenCalledWith(
+      `v1/activity/${activityFixture.activity_id}/close`,
+      '',
+      {
+        'X-Participant-Id': regularParticipantFixture.id,
+      }
+    );
+  });
+});

--- a/frontend/src/application/use-cases/create-activity.usecase.spec.ts
+++ b/frontend/src/application/use-cases/create-activity.usecase.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { of } from 'rxjs';
+
+import { AgileWheelBackEndHTTP } from 'adapters/http/agile-wheel-backend.http';
+import { clearDataFromLocalStorage } from 'adapters/local-storage/utils';
+import {
+  CreateActivityRequest,
+  CreateActivityResponse,
+} from 'application/dtos/create-activity.dto';
+import { activityFixture, ownerParticipantFixture } from 'testing/fixtures';
+
+import { CreateActivityUseCase } from './create-activity.usecase';
+
+describe('CreateActivityUseCase', () => {
+  let usecase: CreateActivityUseCase;
+
+  let httpSpy: jasmine.SpyObj<AgileWheelBackEndHTTP>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  const request: CreateActivityRequest = { name: 'John', email: 'j@x' };
+  const response: CreateActivityResponse = {
+    participant: ownerParticipantFixture,
+    activity: activityFixture,
+  };
+
+  beforeEach(() => {
+    httpSpy = jasmine.createSpyObj<AgileWheelBackEndHTTP>('AgileWheelBackEndHTTP', ['post']);
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    clearDataFromLocalStorage();
+
+    TestBed.configureTestingModule({
+      providers: [
+        CreateActivityUseCase,
+        { provide: AgileWheelBackEndHTTP, useValue: httpSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    usecase = TestBed.inject(CreateActivityUseCase);
+  });
+
+  it('should post create request and store response', done => {
+    // GIVEN
+    httpSpy.post.and.returnValue(of(response));
+
+    // WHEN
+    usecase.execute(request).subscribe(res => {
+      // THEN
+      expect(res).toEqual(response);
+      expect(localStorage.getItem('participant')).toEqual(JSON.stringify(ownerParticipantFixture));
+      expect(localStorage.getItem('activity')).toEqual(JSON.stringify(activityFixture));
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/activity/', activityFixture.activity_id]);
+      done();
+    });
+
+    expect(httpSpy.post).toHaveBeenCalledWith('v1/activity', { owner: request });
+  });
+});

--- a/frontend/src/application/use-cases/enter-activity.usecase.spec.ts
+++ b/frontend/src/application/use-cases/enter-activity.usecase.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { of } from 'rxjs';
+
+import { AgileWheelBackEndHTTP } from 'adapters/http/agile-wheel-backend.http';
+import { clearDataFromLocalStorage } from 'adapters/local-storage/utils';
+import { EnterActivityRequest, EnterActivityResponse } from 'application/dtos/enter-activity.dto';
+import { activityFixture, regularParticipantFixture } from 'testing/fixtures';
+
+import { EnterActivityUseCase } from './enter-activity.usecase';
+
+describe('EnterActivityUseCase', () => {
+  let usecase: EnterActivityUseCase;
+
+  let httpSpy: jasmine.SpyObj<AgileWheelBackEndHTTP>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  const request: EnterActivityRequest = { name: 'John', email: 'j@x' };
+  const response: EnterActivityResponse = {
+    participant: regularParticipantFixture,
+    activity: activityFixture,
+  };
+
+  beforeEach(() => {
+    httpSpy = jasmine.createSpyObj<AgileWheelBackEndHTTP>('AgileWheelBackEndHTTP', ['patch']);
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    clearDataFromLocalStorage();
+
+    TestBed.configureTestingModule({
+      providers: [
+        EnterActivityUseCase,
+        { provide: AgileWheelBackEndHTTP, useValue: httpSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    usecase = TestBed.inject(EnterActivityUseCase);
+  });
+
+  it('should patch join request and store response', done => {
+    // GIVEN
+    httpSpy.patch.and.returnValue(of(response));
+
+    // WHEN
+    usecase.execute('a1', request).subscribe(res => {
+      // THEN
+      expect(res).toEqual(response);
+      expect(localStorage.getItem('participant')).toEqual(
+        JSON.stringify(regularParticipantFixture)
+      );
+      expect(localStorage.getItem('activity')).toEqual(JSON.stringify(activityFixture));
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/activity/', activityFixture.activity_id]);
+      done();
+    });
+
+    expect(httpSpy.patch).toHaveBeenCalledWith('v1/activity/a1/join', { participant: request });
+  });
+});

--- a/frontend/src/application/use-cases/submit-evaluation.usecase.spec.ts
+++ b/frontend/src/application/use-cases/submit-evaluation.usecase.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
+
+import { AgileWheelBackEndHTTP } from 'adapters/http/agile-wheel-backend.http';
+import { activityFixture, ownerParticipantFixture, dimensionsFixture } from 'testing/fixtures';
+
+import { SubmitEvaluationUseCase } from './submit-evaluation.usecase';
+
+describe('SubmitEvaluationUseCase', () => {
+  let usecase: SubmitEvaluationUseCase;
+  let httpSpy: jasmine.SpyObj<AgileWheelBackEndHTTP>;
+
+  beforeEach(() => {
+    httpSpy = jasmine.createSpyObj<AgileWheelBackEndHTTP>('AgileWheelBackEndHTTP', ['post']);
+    httpSpy.post.and.returnValue(of({}));
+
+    TestBed.configureTestingModule({
+      providers: [SubmitEvaluationUseCase, { provide: AgileWheelBackEndHTTP, useValue: httpSpy }],
+    });
+
+    usecase = TestBed.inject(SubmitEvaluationUseCase);
+  });
+
+  it('should post evaluation with built payload', () => {
+    // WHEN
+    usecase.execute(activityFixture, ownerParticipantFixture, dimensionsFixture);
+
+    // THEN
+    expect(httpSpy.post).toHaveBeenCalledWith(
+      `v1/activity/${activityFixture.activity_id}/evaluation`,
+      { ratings: [{ principle_id: 'p', score: 2, comments: '' }] },
+      { 'X-Participant-Id': ownerParticipantFixture.id }
+    );
+  });
+});

--- a/frontend/src/presentations/pages/activity/activity.component.spec.ts
+++ b/frontend/src/presentations/pages/activity/activity.component.spec.ts
@@ -1,0 +1,122 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { Subject } from 'rxjs';
+
+import { ActivityStreamMessage } from 'application/dtos/activity-stream.dto';
+import {
+  ACTIVITY_FLOW_USE_CASE_PORT,
+  ActivityFlowUseCasePort,
+} from 'application/ports/activity-flow-use-case-port';
+import {
+  ACTIVITY_STREAM_USE_CASE_PORT,
+  ActivityStreamUseCasePort,
+} from 'application/ports/activity-stream-use-case-port';
+import { Activity, Participant } from 'domain/model';
+import { activityFixture, regularParticipantFixture, dimensionsFixture } from 'testing/fixtures';
+
+import { ActivityComponent } from './activity.component';
+
+const activity: Activity = {
+  ...activityFixture,
+  dimensions: dimensionsFixture,
+};
+const participant: Participant = regularParticipantFixture;
+
+describe('ActivityComponent', () => {
+  let component: ActivityComponent;
+
+  let stream$: Subject<ActivityStreamMessage>;
+
+  let streamUseCaseSpy: jasmine.SpyObj<ActivityStreamUseCasePort>;
+  let flowUseCaseSpy: jasmine.SpyObj<ActivityFlowUseCasePort>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    stream$ = new Subject<ActivityStreamMessage>();
+
+    streamUseCaseSpy = jasmine.createSpyObj<ActivityStreamUseCasePort>(
+      'ActivityStreamUseCasePort',
+      ['startObserving', 'stopObserving']
+    );
+    streamUseCaseSpy.startObserving.and.returnValue(stream$.asObservable());
+
+    flowUseCaseSpy = jasmine.createSpyObj<ActivityFlowUseCasePort>('ActivityFlowUseCasePort', [
+      'execute',
+    ]);
+
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    localStorage.setItem('activity', JSON.stringify(activity));
+    localStorage.setItem('participant', JSON.stringify(participant));
+
+    await TestBed.configureTestingModule({
+      imports: [ActivityComponent], // standalone
+      providers: [
+        { provide: ACTIVITY_STREAM_USE_CASE_PORT, useValue: streamUseCaseSpy },
+        { provide: ACTIVITY_FLOW_USE_CASE_PORT, useValue: flowUseCaseSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    }).compileComponents();
+
+    component = TestBed.createComponent(ActivityComponent).componentInstance;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    stream$.complete();
+  });
+
+  it('should initialize dimension scores with zero', async () => {
+    // WHEN
+    await component.ngOnInit();
+
+    // THEN
+    expect(component.dimensions[0].principles[0].score).toBe(0);
+  });
+
+  it('should update participants when stream emits', async () => {
+    // GIVEN
+    await component.ngOnInit();
+    const msg: ActivityStreamMessage = {
+      activity_id: 'a1',
+      created_at: 'now',
+      is_opened: true,
+      participants: [{ id: 'p2', name: 'x', email: 'e' }],
+    };
+
+    // WHEN
+    stream$.next(msg);
+
+    // THEN
+    expect(component.participants).toEqual(msg.participants);
+  });
+
+  it('should navigate when activity closes', async () => {
+    // GIVEN
+    await component.ngOnInit();
+    const msg: ActivityStreamMessage = {
+      activity_id: 'a1',
+      created_at: 'now',
+      is_opened: false,
+      participants: [],
+    };
+
+    // WHEN
+    stream$.next(msg);
+
+    // THEN
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['activity/a1/result']);
+  });
+
+  it('should stop observing on destroy', async () => {
+    // GIVEN
+    await component.ngOnInit();
+
+    // WHEN
+    component.ngOnDestroy();
+
+    // THEN
+    expect(streamUseCaseSpy.stopObserving).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/testing/fixtures.ts
+++ b/frontend/src/testing/fixtures.ts
@@ -1,0 +1,54 @@
+import { ActivatedRouteSnapshot } from '@angular/router';
+
+import { Activity, DimensionWithScores, Participant } from 'domain/model';
+
+export const regularParticipantFixture: Participant = {
+  id: 'p1',
+  name: 'Regular',
+  email: 'j@x',
+};
+
+export const ownerParticipantFixture: Participant = {
+  id: 'o1',
+  name: 'Owner',
+  email: 'j@x',
+};
+
+export const dimensionsFixture: DimensionWithScores[] = [
+  {
+    id: 'd1',
+    name: 'dim',
+    principles: [{ id: 'p', name: 'p', score: 2 }],
+  },
+];
+
+export const activityFixture: Activity = {
+  activity_id: 'a1',
+  created_at: 'now',
+  is_opened: true,
+  owner: ownerParticipantFixture,
+  participants: [],
+  dimensions: [],
+  evaluations: [],
+};
+
+export function createRoute(id?: string): ActivatedRouteSnapshot {
+  return {
+    paramMap: { get: (key: string) => (key === 'id' ? (id ?? null) : null) },
+  } as ActivatedRouteSnapshot;
+}
+
+export function mockLocalStorage(
+  activity: Activity | null,
+  participant: Participant | null
+): void {
+  spyOn(localStorage, 'getItem').and.callFake((key: string) => {
+    if (key === 'activity') {
+      return activity ? JSON.stringify(activity) : null;
+    }
+    if (key === 'participant') {
+      return participant ? JSON.stringify(participant) : null;
+    }
+    return null;
+  });
+}


### PR DESCRIPTION
This pull request introduces several unit tests for various use cases and components in the frontend application, as well as updates to fixtures to support testing. The most important changes include adding unit tests for guards, use cases, and components, as well as enhancing testing utilities with new fixtures.

### Unit Tests for Guards
* [`frontend/src/application/guards/validate-activity.guard.spec.ts`](diffhunk://#diff-0a947350839399097641697bdf283e63bf5f7e5e93915a43eeb4f108da759322R1-R100): Added tests for the `ValidateActitivityGuard` to ensure proper navigation behavior based on activity ID and local storage data.

### Unit Tests for Use Cases
* [`frontend/src/application/use-cases/create-activity.usecase.spec.ts`](diffhunk://#diff-d6c12d9b2b64592c6021fe1b924e67cdb66c339d2c9a69a824257044f029a227R1-R61): Added tests for `CreateActivityUseCase` to verify correct backend interaction, local storage updates, and navigation.
* [`frontend/src/application/use-cases/enter-activity.usecase.spec.ts`](diffhunk://#diff-3dc0e391ff47b1aecdf66422e7248f2ed873fb18eb9f5e05e880c9125cca3356R1-R60): Added tests for `EnterActivityUseCase` to validate joining an activity and storing participant data.
* [`frontend/src/application/use-cases/close-activity.usecase.spec.ts`](diffhunk://#diff-372c12d5ec3daf3ca2323305a0998230fd0ff222d745ffd35354407ee5f45397R1-R39): Added tests for `CloseActivityUserCase` to ensure the backend is called with the correct endpoint and headers.
* [`frontend/src/application/use-cases/submit-evaluation.usecase.spec.ts`](diffhunk://#diff-c42a8a8b07254b5341a1b87eeade3febfc6b1b0824c1267fe83b4bc58454725aR1-R36): Added tests for `SubmitEvaluationUseCase` to confirm payload construction and backend interaction for evaluations.

### Unit Tests for Components
* [`frontend/src/presentations/pages/activity/activity.component.spec.ts`](diffhunk://#diff-76244e5b4983f57bfb0bbd5b0ac7293f774658e7217eff6e644275584752d620R1-R122): Added tests for `ActivityComponent` to verify initialization, participant updates, navigation on activity closure, and stream observation lifecycle.

### Testing Utilities Enhancements
* [`frontend/src/testing/fixtures.ts`](diffhunk://#diff-9bf276ec5c8fc6e22b29a6690d054e967677de717f91873c7a5a27ea8e7680eaR1-R54): Added new fixtures for `Activity`, `Participant`, and `DimensionWithScores` to simplify test setup. Introduced helper functions like `createRoute` and `mockLocalStorage` for mocking route parameters and local storage.

### Minor Fixes
* [`frontend/sonar-project.properties`](diffhunk://#diff-8b22cde35788a01d5a06d045770f2ca27d54d7d201a655f24e839d0801e53448L7-R8): Adjusted SonarCloud coverage exclusions to include `.spec.ts` files while excluding other files.