### PR TITLE
feat: update documentation and add GitHub Actions for MkDocs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,28 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v3
+
+      - name: Configurar Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12.0'
+
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Build and deploy
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+site

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=agile-wheel-frontend&metric=alert_status&token=a46c4dbfd6dcc1ede0341d0e17c158a7f1d2c58b)](https://sonarcloud.io/summary/new_code?id=agile-wheel-frontend) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=agile-wheel-frontend&metric=reliability_rating&token=a46c4dbfd6dcc1ede0341d0e17c158a7f1d2c58b)](https://sonarcloud.io/summary/new_code?id=agile-wheel-frontend) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=agile-wheel-frontend&metric=coverage&token=a46c4dbfd6dcc1ede0341d0e17c158a7f1d2c58b)](https://sonarcloud.io/summary/new_code?id=agile-wheel-frontend) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=agile-wheel-frontend&metric=sqale_rating&token=a46c4dbfd6dcc1ede0341d0e17c158a7f1d2c58b)](https://sonarcloud.io/summary/new_code?id=agile-wheel-frontend)
 
+## 🔗 Links Rápidos
+
+- 🚀 [Aplicação em produção](https://agilewheel.miguelsmuller.dev.br/)  
+- 📘 [Documentação online](https://miguelsmuller.github.io/agile-wheel/)
 
 ## 📘 Agile Wheel Documentation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Agile Wheel Documentation
 
 docs_dir: docs
 
+site_url: https://miguelsmuller.github.io/agile-wheel/
 repo_url: https://github.com/miguelsmuller/agile-wheel
 
 nav:


### PR DESCRIPTION
This pull request introduces a workflow for deploying MkDocs documentation to GitHub Pages, updates the `README.md` with quick links for better accessibility, and enhances the `mkdocs.yml` configuration by adding the site URL. Below is a summary of the most important changes grouped by theme:

### Deployment Workflow for Documentation:
* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R1-R28): Added a new GitHub Actions workflow to automate the deployment of MkDocs documentation to GitHub Pages. It includes steps for checking out code, setting up Python, installing dependencies, and deploying the documentation.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R14): Added a "Quick Links" section with links to the production application and online documentation for easier navigation.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R5): Updated the configuration to include the `site_url` pointing to the online documentation hosted on GitHub Pages.