### PR TITLE
feat: add API token to deployment environment variables

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -147,7 +147,8 @@ jobs:
             ENABLE_PROFILING=${{ vars.ENABLE_PROFILING }}
 
             ALLOWED_ORIGINS=${{ vars.ALLOWED_ORIGINS }}
-            
+            API_TOKEN=${{ secrets.API_TOKEN }}
+
             SENTRY_DNS=${{ vars.SENTRY_DNS }}
           service: 'agile-wheel-backend'
           image: 'docker.io/miguelsmuller/agile-wheel-backend:latest'


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow configuration. It adds a new environment variable to securely pass the API token during the deployment process.

* [`.github/workflows/deploy-backend.yml`](diffhunk://#diff-2418b8c74e15fc5d4f708e1f98749f0d592abf1991ce915d251f77ed076e5f7dR150): Added `API_TOKEN` as a secret to the deployment workflow to ensure secure access to the API during deployment.